### PR TITLE
fix: check for Cargo.toml instead of disallow 'src/'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
             the_original_path.close().unwrap();
         }
         None => {
-            if path.to_string_lossy().contains("src") || path.to_string_lossy().contains("target") {
+            if !path.join("Cargo.toml").exists() {
                 println!("Please run this command on the root of the rust project");
                 std::process::exit(1);
             }


### PR DESCRIPTION
Hello.

I was trying to use `cargo-warehouse`, but I keep my source files under a directory like `$HOME/src/project_a` etc.
I figure this is a better check.

Thanks for your consideration.